### PR TITLE
Update userAgent detection including BlackBerry 10

### DIFF
--- a/source/parallax.js
+++ b/source/parallax.js
@@ -188,7 +188,7 @@
   Parallax.prototype.hw = null;
   Parallax.prototype.hh = null;
   Parallax.prototype.portrait = null;
-  Parallax.prototype.desktop = !navigator.userAgent.match(/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/);
+  Parallax.prototype.desktop = !navigator.userAgent.match(/(iPhone|iPod|iPad|Android|BlackBerry|BB10|IEMobile)/);
   Parallax.prototype.vendors = ['O','ms','Moz','webkit',null];
   Parallax.prototype.motionSupport = window.DeviceMotionEvent !== undefined;
   Parallax.prototype.orientationSupport = window.DeviceOrientationEvent !== undefined;


### PR DESCRIPTION
BlackBerry 10 has a new userAgent:

Mozilla/5.0 (BB10; <Device Model>) AppleWebKit/<WebKit Version> (KHTML, like Gecko) Version/<BB Version #> Mobile Safari/<WebKit Version>
