### PR TITLE
Added instructions for using Parallax on native UIWebView

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ it to the **Parallax** constructor.
 var scene = document.getElementById('scene');
 var parallax = new Parallax(scene);
 ```
+## iOS
+
+If your application is a webapp (i.e. will run on Safari), then there is nothing you need to do. 
+If you are writing a native application and would like to use a `UIWebView` using this
+framework, then you will need to do a bit more work to get the parallax effect. UIWebViews no longer get
+the deviceorientation event. So, the native app has to intercept the gyro events and reroute them to the
+UIWebView:
+
+1. First, include the CoreMotion framework as `#import <CoreMotion/CoreMotion.h>` and have a reference 
+to the UIWebView (eg. add it as a property: `@property(nonatomic,strong) IBOutlet UIWebView *parallaxWebView;`)
+2. Add a property to the app delegate (or whatever controller will own the UIWebView you wish to add parallax on) `@property(nonatomic,strong) CMMotionManager *motionManager;`
+3. Finally, make the following calls:
+
+```Objective-C
+  self.motionManager = [[CMMotionManager alloc] init];
+  
+  if(self.motionManager.isGyroAvailable && !self.motionManager.isGyroActive) {
+  
+    [self.motionManager setGyroUpdateInterval:0.5f]; // send event every half second
+            
+    [self.motionManager startGyroUpdatesToQueue:NSOperationQueue.mainQueue
+                                            withHandler:^(CMGyroData *gyroData, NSError *error) {
+                 
+                 NSString *js =[NSString stringWithFormat:@"parallax.onDeviceOrientation({beta : %f, gamma : %f})", gyroData.rotationRate.x, gyroData.rotationRate.y];
+                 [self.parallaxWebView stringByEvaluatingJavaScriptFromString:js];
+             }];
+  }
+```
+This will send the latest gyro (x and y rotations) to the UIWebView. 
 
 ## Behaviours
 


### PR DESCRIPTION
First of all, thank you for an impressive framework. I am using your fwk to add a parallax effect on the background 'image' of the onboarding screen on my app. Works great. However, the native app needs to explicitly inform Parallax of gyro events.
