### PR TITLE
to support Windows Tablet (tested on Surface 2) and Windows Phone (from ...

### DIFF
--- a/deploy/parallax.js
+++ b/deploy/parallax.js
@@ -37,7 +37,6 @@
  *              If no gyroscope is available, the cursor position is used.
  */
 ;(function(window, document, undefined) {
-
   // Strict Mode
   'use strict';
 
@@ -127,7 +126,6 @@
     // Callbacks
     this.onMouseMove = this.onMouseMove.bind(this);
     this.onDeviceOrientation = this.onDeviceOrientation.bind(this);
-    this.onOrientationTimer = this.onOrientationTimer.bind(this);
     this.onCalibrationTimer = this.onCalibrationTimer.bind(this);
     this.onAnimationFrame = this.onAnimationFrame.bind(this);
     this.onWindowResize = this.onWindowResize.bind(this);
@@ -268,16 +266,11 @@
   Parallax.prototype.enable = function() {
     if (!this.enabled) {
       this.enabled = true;
-      if (this.orientationSupport) {
-        this.portrait = null;
-        window.addEventListener('deviceorientation', this.onDeviceOrientation);
-        setTimeout(this.onOrientationTimer, this.supportDelay);
-      } else {
-        this.cx = 0;
-        this.cy = 0;
-        this.portrait = false;
-        window.addEventListener('mousemove', this.onMouseMove);
-      }
+      this.portrait = null;
+      window.addEventListener('deviceorientation', this.onDeviceOrientation);
+      this.cx = 0;
+      this.cy = 0;
+      window.addEventListener('mousemove', this.onMouseMove);
       window.addEventListener('resize', this.onWindowResize);
       this.raf = requestAnimationFrame(this.onAnimationFrame);
     }
@@ -286,11 +279,8 @@
   Parallax.prototype.disable = function() {
     if (this.enabled) {
       this.enabled = false;
-      if (this.orientationSupport) {
-        window.removeEventListener('deviceorientation', this.onDeviceOrientation);
-      } else {
-        window.removeEventListener('mousemove', this.onMouseMove);
-      }
+      window.removeEventListener('deviceorientation', this.onDeviceOrientation);
+      window.removeEventListener('mousemove', this.onMouseMove);
       window.removeEventListener('resize', this.onWindowResize);
       cancelAnimationFrame(this.raf);
     }
@@ -361,14 +351,6 @@
     }
   };
 
-  Parallax.prototype.onOrientationTimer = function(event) {
-    if (this.orientationSupport && this.orientationStatus === 0) {
-      this.disable();
-      this.orientationSupport = false;
-      this.enable();
-    }
-  };
-
   Parallax.prototype.onCalibrationTimer = function(event) {
     this.calibrationFlag = true;
   };
@@ -409,9 +391,8 @@
   };
 
   Parallax.prototype.onDeviceOrientation = function(event) {
-
-    // Validate environment and event properties.
-    if (!this.desktop && event.beta !== null && event.gamma !== null) {
+    // Validate environment and event properties: ch: REMOVED !this.desktop as event properties should be ok
+    if (event.beta !== null && event.gamma !== null) {
 
       // Set orientation status.
       this.orientationStatus = 1;

--- a/source/parallax.js
+++ b/source/parallax.js
@@ -6,7 +6,6 @@
  *              If no gyroscope is available, the cursor position is used.
  */
 ;(function(window, document, undefined) {
-
   // Strict Mode
   'use strict';
 
@@ -96,7 +95,6 @@
     // Callbacks
     this.onMouseMove = this.onMouseMove.bind(this);
     this.onDeviceOrientation = this.onDeviceOrientation.bind(this);
-    this.onOrientationTimer = this.onOrientationTimer.bind(this);
     this.onCalibrationTimer = this.onCalibrationTimer.bind(this);
     this.onAnimationFrame = this.onAnimationFrame.bind(this);
     this.onWindowResize = this.onWindowResize.bind(this);
@@ -237,16 +235,11 @@
   Parallax.prototype.enable = function() {
     if (!this.enabled) {
       this.enabled = true;
-      if (this.orientationSupport) {
-        this.portrait = null;
-        window.addEventListener('deviceorientation', this.onDeviceOrientation);
-        setTimeout(this.onOrientationTimer, this.supportDelay);
-      } else {
-        this.cx = 0;
-        this.cy = 0;
-        this.portrait = false;
-        window.addEventListener('mousemove', this.onMouseMove);
-      }
+      this.portrait = null;
+      window.addEventListener('deviceorientation', this.onDeviceOrientation);
+      this.cx = 0;
+      this.cy = 0;
+      window.addEventListener('mousemove', this.onMouseMove);
       window.addEventListener('resize', this.onWindowResize);
       this.raf = requestAnimationFrame(this.onAnimationFrame);
     }
@@ -255,11 +248,8 @@
   Parallax.prototype.disable = function() {
     if (this.enabled) {
       this.enabled = false;
-      if (this.orientationSupport) {
-        window.removeEventListener('deviceorientation', this.onDeviceOrientation);
-      } else {
-        window.removeEventListener('mousemove', this.onMouseMove);
-      }
+      window.removeEventListener('deviceorientation', this.onDeviceOrientation);
+      window.removeEventListener('mousemove', this.onMouseMove);
       window.removeEventListener('resize', this.onWindowResize);
       cancelAnimationFrame(this.raf);
     }
@@ -330,14 +320,6 @@
     }
   };
 
-  Parallax.prototype.onOrientationTimer = function(event) {
-    if (this.orientationSupport && this.orientationStatus === 0) {
-      this.disable();
-      this.orientationSupport = false;
-      this.enable();
-    }
-  };
-
   Parallax.prototype.onCalibrationTimer = function(event) {
     this.calibrationFlag = true;
   };
@@ -378,9 +360,8 @@
   };
 
   Parallax.prototype.onDeviceOrientation = function(event) {
-
-    // Validate environment and event properties.
-    if (!this.desktop && event.beta !== null && event.gamma !== null) {
+    // Validate environment and event properties: ch: REMOVED !this.desktop as event properties should be ok
+    if (event.beta !== null && event.gamma !== null) {
 
       // Set orientation status.
       this.orientationStatus = 1;


### PR DESCRIPTION
...8.1/IE11) removed desktop check and orientationSupport check. Seems easiest to simply support both orientation AND mouse events, no harm done I think.

I guess you tested on way more devices and may have reasons for the rather complicated checks for deviceorientation event and desktop support but I think simply using all available events is best. They should not interfere as will probably not happen at the same time on same device anyway (only case might be a hybrid Laptop user using mouse and moving his laptop/tablet at the same time. Even then it might work.

Orientation works on Windows Phone 8.1 which has IE 11 and is not recognized as a mobile device. Therefor the removal of the desktop check.

It also works on Windows 8.1 (RT on Surface 2 tested) where somehow the extra check for deviceorientation support made problems (and as described above should be not needed anyway). Somehow the directions on Surface are swapped (LeftRight is TopDown etc) but I had not the time to check why this happens and only tested the simple example anyway.

Hope you might be able to use the changes. Any comments would be great, thanks!
