### PR TITLE
bower.json main should have only one copy of the main script.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,9 +9,7 @@
   ],
   "main": [
     "deploy/parallax.js",
-    "deploy/parallax.min.js",
-    "deploy/jquery.parallax.js",
-    "deploy/jquery.parallax.min.js"
+    "deploy/jquery.parallax.js"
   ],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
I've just added parallax.js to the project I'm currently working. 

In my flow I use wiredep to inject & manage all the `<script...>` tags used by bower libraries. Right now parallax is injecting both, minified and unminified file into the html. 

I've updated bower.json so only contains both unminidifed files.
