### PR TITLE
Update jquery.parallax.js to fix the updateLayers();

### DIFF
--- a/source/jquery.parallax.js
+++ b/source/jquery.parallax.js
@@ -220,7 +220,7 @@
 
     // Cache Depths
     this.$layers.each($.proxy(function(index, element) {
-      this.depths.push($(element).data('depth') || 0);
+      this.depths.push($(element).attr('data-depth') || 0);
     }, this));
   };
 


### PR DESCRIPTION
Fixing the updateLayers(); function which doesn't update the layer motion after setting new data-depth.
#79
