### PR TITLE
Fix a jumpiness issue in Firefox and Edge

### DIFF
--- a/source/parallax.js
+++ b/source/parallax.js
@@ -394,7 +394,7 @@
   };
 
   Parallax.prototype.accelerate = function(element) {
-    this.css(element, 'transform', 'translate3d(0,0,0)');
+    this.css(element, 'transform', 'translate3d(0,0,0) rotate(0.0001deg)');
     this.css(element, 'transform-style', 'preserve-3d');
     this.css(element, 'backface-visibility', 'hidden');
   };


### PR DESCRIPTION
Adding rotate(0.0001deg) to the container makes the parallax animation more smooth in these browsers. Adding this forces Firefox and Edge to stop aligning to pixel boundaries.