### PR TITLE
Changed Parallax name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "parallax-js",
+  "name": "parallax",
   "description": "Parallax Engine that reacts to the orientation of a smart device.",
   "license": "MIT",
   "homepage": "http://wagerfield.github.io/parallax/",


### PR DESCRIPTION
The parallax-js is another plugin in the Bower, the correct name of your project is "parallax".