### PR TITLE
add option to use inline styles for positioning

### DIFF
--- a/src/parallax.js
+++ b/src/parallax.js
@@ -149,7 +149,8 @@ const MAGIC_NUMBER = 30,
         pointerEvents: false,
         precision: 1,
         onReady: null,
-        selector: null
+        selector: null,
+        useInlinePosition: true
       }
 
 class Parallax {
@@ -302,10 +303,12 @@ class Parallax {
         helpers.accelerate(layer)
       }
 
-      layer.style.position = index ? 'absolute' : 'relative'
-      layer.style.display = 'block'
-      layer.style.left = 0
-      layer.style.top = 0
+      if (this.useInlinePosition) {
+        layer.style.position = index ? 'absolute' : 'relative'
+        layer.style.display = 'block'
+        layer.style.left = 0
+        layer.style.top = 0
+      }
 
       let depth = helpers.data(layer, 'depth') || 0
       this.depthsX.push(helpers.data(layer, 'depth-x') || depth)


### PR DESCRIPTION
Solves issues #242 and #273.

In some cases, using inline styles for positioning parallax elements forces developers to override css properties with `!important`, which is inelegant at best and impossible at worst.

I added a `useInlinePosition` option (set to true, which is the current behavior, so it does not break anything) to stop using inline positioning for parallax elements.

I did not update the data attribute API because this is a behavior which is normally decided on website level, not element-by-element.